### PR TITLE
Use functions.sh from /lib instead of /etc. OpenWRT builds no longer …

### DIFF
--- a/openflow-1.3/files/sbin/ofdown
+++ b/openflow-1.3/files/sbin/ofdown
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Copyright (C) 2006 OpenWrt.org
 
-. /etc/functions.sh
+. /lib/functions.sh
 [ $# = 0 ] && { echo "  $0 <group>"; exit; }
 [ "x$1" = "x-a" ] && {
 	config_cb() {

--- a/openflow-1.3/files/sbin/ofup
+++ b/openflow-1.3/files/sbin/ofup
@@ -2,7 +2,7 @@
 # Copyright (C) 2006 OpenWrt.org
 
 /sbin/ofdown "$@"
-. /etc/functions.sh
+. /lib/functions.sh
 
 if [ -x /etc/preopenflow.user ]
 then


### PR DESCRIPTION
…include the /etc/functions.sh symlink. I made the simple change and [here's](https://dev.openwrt.org/ticket/12645) one example of some work to use /lib/functions.sh.
